### PR TITLE
docs(profile): уточнить описание мета-тега страницы профиля

### DIFF
--- a/packages/client/src/pages/Profile/index.tsx
+++ b/packages/client/src/pages/Profile/index.tsx
@@ -138,7 +138,7 @@ export const ProfilePage = () => {
 
   return (
     <WrapperContent className="max-w-[600px] items-center justify-center text-center">
-      <PageMeta title="Профиль - Dino Game" description="Профиль пользователя" />
+      <PageMeta title="Профиль - Dino Game" description="Страница профиля пользователя" />
 
       {loading && !user && <p>Загрузка...</p>}
       {user && (


### PR DESCRIPTION
### Какую задачу решаем

Уточнён мета-тег `description` страницы профиля: было `"Профиль пользователя"`, стало `"Страница профиля пользователя"` - более точно описывает страницу для SEO/доступности.

Closes #6