### PR TITLE
Feature/issue-50 Forum reactions emoji

### DIFF
--- a/packages/client/src/pages/Forum/index.tsx
+++ b/packages/client/src/pages/Forum/index.tsx
@@ -7,6 +7,8 @@ import {
   fetchCommentsThunk,
   createTopicThunk,
   createCommentThunk,
+  toggleCommentReactionThunk,
+  FORUM_REACTION_EMOJIS,
   selectTopics,
   selectCurrentComments,
   selectForumLoading,
@@ -84,6 +86,17 @@ export const ForumPage = () => {
       })
     )
     setNewComment('')
+  }
+
+  const handleToggleReaction = (commentId: number, emoji: string) => {
+    if (!selectedTopic || !user) return
+
+    dispatch(
+      toggleCommentReactionThunk({
+        commentId,
+        emoji,
+      })
+    )
   }
 
   return (
@@ -201,6 +214,29 @@ export const ForumPage = () => {
                     </span>
                   </div>
                   <p className="text-base text-primary-foreground">{comment.content}</p>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {FORUM_REACTION_EMOJIS.map(emoji => {
+                      const count =
+                        comment.reactionSummary.find(reaction => reaction.emoji === emoji)?.count ||
+                        0
+                      const isSelected = comment.myReactions.includes(emoji)
+
+                      return (
+                        <button
+                          key={`${comment.id}-${emoji}`}
+                          type="button"
+                          onClick={() => handleToggleReaction(comment.id, emoji)}
+                          className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                            isSelected
+                              ? 'bg-primary/40 text-foreground border-primary/20 text-white'
+                              : 'bg-card text-card-foreground hover:bg-muted'
+                          }`}>
+                          {emoji} {count > 0 ? count : ''}
+                        </button>
+                      )
+                    })}
+                  </div>
                 </div>
               ))}
             </div>

--- a/packages/client/src/slices/forum.types.ts
+++ b/packages/client/src/slices/forum.types.ts
@@ -15,7 +15,14 @@ export interface Comment {
   parentId: number | null
   createdAt: string
   updatedAt: string
+  reactionSummary: ReactionSummaryItem[]
+  myReactions: string[]
   replies?: Comment[]
+}
+
+export interface ReactionSummaryItem {
+  emoji: string
+  count: number
 }
 
 export interface ForumState {
@@ -23,4 +30,5 @@ export interface ForumState {
   currentComments: Comment[]
   isLoading: boolean
   error: string | null
+  latestReactionRequestByCommentId: Record<string, string>
 }

--- a/packages/client/src/slices/forumSlice.ts
+++ b/packages/client/src/slices/forumSlice.ts
@@ -1,24 +1,113 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '@/store'
 import { SERVER_HOST2 } from '@/constants'
-import { Topic, Comment, ForumState } from './forum.types'
+import { Topic, Comment, ForumState, ReactionSummaryItem } from './forum.types'
+
+export const FORUM_REACTION_EMOJIS = ['👍', '❤️', '😂', '🎉', '😮', '😢', '👎'] as const
+
+type ToggleReactionPayload = {
+  commentId: number
+  emoji: string
+}
+
+type ToggleReactionResponse = {
+  status: 'added' | 'removed'
+  comment_id: number
+  reactionSummary: ReactionSummaryItem[]
+  myReactions: string[]
+}
 
 const initialState: ForumState = {
   topics: [],
   currentComments: [],
   isLoading: false,
   error: null,
+  latestReactionRequestByCommentId: {},
 }
 
 const fetchOptions = {}
+const fetchWithCredentials = {
+  ...fetchOptions,
+  credentials: 'include' as const,
+}
 
 const getAuthHeaders = (state: RootState) => {
-  const userId = state.user.data?.id || '1'
-  return {
+  const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'x-auth-user-id': String(userId),
+  }
+
+  const userId = state.user.data?.id
+  if (userId) {
+    headers['x-auth-user-id'] = String(userId)
+  }
+
+  return headers
+}
+
+const normalizeCommentTree = (comment: Comment): Comment => ({
+  ...comment,
+  reactionSummary: Array.isArray(comment.reactionSummary) ? comment.reactionSummary : [],
+  myReactions: Array.isArray(comment.myReactions) ? comment.myReactions : [],
+  replies: Array.isArray(comment.replies) ? comment.replies.map(normalizeCommentTree) : [],
+})
+
+const sortReactionSummary = (summary: ReactionSummaryItem[]) => {
+  const order: Record<string, number> = {}
+  FORUM_REACTION_EMOJIS.forEach((emoji, index) => {
+    order[emoji] = index
+  })
+  return [...summary].sort((left, right) => (order[left.emoji] || 0) - (order[right.emoji] || 0))
+}
+
+const toggleLocalReaction = (comment: Comment, emoji: string): Comment => {
+  const reactionSummaryMap = new Map(comment.reactionSummary.map(item => [item.emoji, item.count]))
+  const myReactionsSet = new Set(comment.myReactions)
+  const alreadySelected = myReactionsSet.has(emoji)
+
+  if (alreadySelected) {
+    myReactionsSet.delete(emoji)
+    const nextCount = Math.max((reactionSummaryMap.get(emoji) || 0) - 1, 0)
+    if (nextCount === 0) {
+      reactionSummaryMap.delete(emoji)
+    } else {
+      reactionSummaryMap.set(emoji, nextCount)
+    }
+  } else {
+    myReactionsSet.add(emoji)
+    reactionSummaryMap.set(emoji, (reactionSummaryMap.get(emoji) || 0) + 1)
+  }
+
+  return {
+    ...comment,
+    reactionSummary: sortReactionSummary(
+      Array.from(reactionSummaryMap.entries()).map(([reactionEmoji, count]) => ({
+        emoji: reactionEmoji,
+        count,
+      }))
+    ),
+    myReactions: FORUM_REACTION_EMOJIS.filter(reactionEmoji => myReactionsSet.has(reactionEmoji)),
   }
 }
+
+const updateCommentTree = (
+  comments: Comment[],
+  commentId: number,
+  updater: (comment: Comment) => Comment
+): Comment[] =>
+  comments.map(comment => {
+    if (comment.id === commentId) {
+      return updater(comment)
+    }
+
+    if (comment.replies && comment.replies.length > 0) {
+      return {
+        ...comment,
+        replies: updateCommentTree(comment.replies, commentId, updater),
+      }
+    }
+
+    return comment
+  })
 
 // Thunks
 export const fetchTopicsThunk = createAsyncThunk(
@@ -26,7 +115,7 @@ export const fetchTopicsThunk = createAsyncThunk(
   async (_, { getState, rejectWithValue }) => {
     const state = getState() as RootState
     const res = await fetch(`${SERVER_HOST2}/api/forum/topics`, {
-      ...fetchOptions,
+      ...fetchWithCredentials,
       headers: getAuthHeaders(state),
     })
     if (!res.ok) {
@@ -44,7 +133,7 @@ export const createTopicThunk = createAsyncThunk(
   ) => {
     const state = getState() as RootState
     const res = await fetch(`${SERVER_HOST2}/api/forum/topics`, {
-      ...fetchOptions,
+      ...fetchWithCredentials,
       method: 'POST',
       headers: getAuthHeaders(state),
       body: JSON.stringify(payload),
@@ -61,7 +150,7 @@ export const fetchCommentsThunk = createAsyncThunk(
   async (topicId: number, { getState, rejectWithValue }) => {
     const state = getState() as RootState
     const res = await fetch(`${SERVER_HOST2}/api/forum/topics/${topicId}/comments`, {
-      ...fetchOptions,
+      ...fetchWithCredentials,
       headers: getAuthHeaders(state),
     })
     if (!res.ok) {
@@ -79,7 +168,7 @@ export const createCommentThunk = createAsyncThunk(
   ) => {
     const state = getState() as RootState
     const res = await fetch(`${SERVER_HOST2}/api/forum/topics/${payload.topic_id}/comments`, {
-      ...fetchOptions,
+      ...fetchWithCredentials,
       method: 'POST',
       headers: getAuthHeaders(state),
       body: JSON.stringify(payload),
@@ -90,6 +179,31 @@ export const createCommentThunk = createAsyncThunk(
     return (await res.json()) as Comment
   }
 )
+
+export const toggleCommentReactionThunk = createAsyncThunk<
+  ToggleReactionResponse & ToggleReactionPayload,
+  ToggleReactionPayload,
+  { state: RootState; rejectValue: string }
+>('forum/toggleCommentReaction', async (payload, { getState, rejectWithValue }) => {
+  const state = getState()
+  const res = await fetch(`${SERVER_HOST2}/api/forum/comments/${payload.commentId}/reactions`, {
+    ...fetchWithCredentials,
+    method: 'POST',
+    headers: getAuthHeaders(state),
+    body: JSON.stringify({ emoji: payload.emoji }),
+  })
+
+  if (!res.ok) {
+    return rejectWithValue('Failed to toggle reaction')
+  }
+
+  const data = (await res.json()) as ToggleReactionResponse
+
+  return {
+    ...payload,
+    ...data,
+  }
+})
 
 export const forumSlice = createSlice({
   name: 'forum',
@@ -125,7 +239,8 @@ export const forumSlice = createSlice({
       })
 
       .addCase(fetchCommentsThunk.fulfilled, (state, { payload }: PayloadAction<Comment[]>) => {
-        state.currentComments = payload
+        state.currentComments = payload.map(normalizeCommentTree)
+        state.latestReactionRequestByCommentId = {}
       })
 
       .addCase(createCommentThunk.pending, state => {
@@ -133,11 +248,57 @@ export const forumSlice = createSlice({
       })
       .addCase(createCommentThunk.fulfilled, (state, { payload }: PayloadAction<Comment>) => {
         if (!payload.parentId) {
-          state.currentComments.push(payload)
+          state.currentComments.push(normalizeCommentTree(payload))
         }
       })
       .addCase(createCommentThunk.rejected, (state, action) => {
         state.error = action.payload as string
+      })
+
+      .addCase(toggleCommentReactionThunk.pending, (state, action) => {
+        state.error = null
+        state.latestReactionRequestByCommentId[String(action.meta.arg.commentId)] =
+          action.meta.requestId
+        state.currentComments = updateCommentTree(
+          state.currentComments,
+          action.meta.arg.commentId,
+          comment => toggleLocalReaction(comment, action.meta.arg.emoji)
+        )
+      })
+      .addCase(toggleCommentReactionThunk.fulfilled, (state, action) => {
+        const commentKey = String(action.payload.commentId)
+        const latestRequestId = state.latestReactionRequestByCommentId[commentKey]
+
+        if (latestRequestId !== action.meta.requestId) {
+          return
+        }
+
+        state.currentComments = updateCommentTree(
+          state.currentComments,
+          action.payload.commentId,
+          comment => ({
+            ...comment,
+            reactionSummary: sortReactionSummary(action.payload.reactionSummary),
+            myReactions: action.payload.myReactions,
+          })
+        )
+        delete state.latestReactionRequestByCommentId[commentKey]
+      })
+      .addCase(toggleCommentReactionThunk.rejected, (state, action) => {
+        const commentKey = String(action.meta.arg.commentId)
+        const latestRequestId = state.latestReactionRequestByCommentId[commentKey]
+
+        if (latestRequestId !== action.meta.requestId) {
+          return
+        }
+
+        state.currentComments = updateCommentTree(
+          state.currentComments,
+          action.meta.arg.commentId,
+          comment => toggleLocalReaction(comment, action.meta.arg.emoji)
+        )
+        state.error = (action.payload as string) || 'Failed to toggle reaction'
+        delete state.latestReactionRequestByCommentId[commentKey]
       })
   },
 })

--- a/packages/server/lib/reactions.ts
+++ b/packages/server/lib/reactions.ts
@@ -1,0 +1,57 @@
+import type { Request } from 'express'
+import { getUserIdFromSession } from '../auth/session'
+
+export const ALLOWED_REACTION_EMOJIS = ['👍', '❤️', '😂', '🎉', '😮', '😢', '👎'] as const
+
+export type ReactionSummaryItem = {
+  emoji: string
+  count: number
+}
+
+export function isAllowedReactionEmoji(emoji: string): boolean {
+  return ALLOWED_REACTION_EMOJIS.includes(emoji as (typeof ALLOWED_REACTION_EMOJIS)[number])
+}
+
+export function extractUserId(req: Request): number | null {
+  const sessionUserId = getUserIdFromSession(req)
+
+  if (sessionUserId !== null) {
+    return sessionUserId
+  }
+
+  const headerUserId = req.headers['x-auth-user-id']
+
+  if (typeof headerUserId === 'string') {
+    const parsed = Number(headerUserId)
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+export function summarizeReactions(
+  reactions: Array<{ emoji: string; user_id: number }>,
+  currentUserId: number | null
+): { reactionSummary: ReactionSummaryItem[]; myReactions: string[] } {
+  const counts = new Map<string, number>()
+  const myReactionsSet = new Set<string>()
+
+  for (const reaction of reactions) {
+    counts.set(reaction.emoji, (counts.get(reaction.emoji) || 0) + 1)
+
+    if (currentUserId !== null && reaction.user_id === currentUserId) {
+      myReactionsSet.add(reaction.emoji)
+    }
+  }
+
+  const reactionSummary = ALLOWED_REACTION_EMOJIS.map(emoji => ({
+    emoji,
+    count: counts.get(emoji) || 0,
+  })).filter(item => item.count > 0)
+
+  const myReactions = ALLOWED_REACTION_EMOJIS.filter(emoji => myReactionsSet.has(emoji))
+
+  return { reactionSummary, myReactions }
+}

--- a/packages/server/models/Reaction.ts
+++ b/packages/server/models/Reaction.ts
@@ -3,15 +3,18 @@ import { Comment } from './Comment'
 
 @Table({ tableName: 'reactions' })
 export class Reaction extends Model {
+  @Index({ name: 'reactions_comment_user_emoji_unique', unique: true })
   @Column({ type: DataType.STRING, allowNull: false })
   emoji!: string
 
   @Index
+  @Index({ name: 'reactions_comment_user_emoji_unique', unique: true })
   @ForeignKey(() => Comment)
   @Column({ type: DataType.INTEGER, allowNull: false })
   comment_id!: number
 
   @Index
+  @Index({ name: 'reactions_comment_user_emoji_unique', unique: true })
   @Column({ type: DataType.INTEGER, allowNull: false })
   user_id!: number
 

--- a/packages/server/routes/commentRouter.ts
+++ b/packages/server/routes/commentRouter.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express'
 import { Comment } from '../models/Comment'
 import { Reaction } from '../models/Reaction'
 import { sanitize } from '../middleware/sanitize'
+import { extractUserId, isAllowedReactionEmoji, summarizeReactions } from '../lib/reactions'
 
 export const commentRouter = Router()
 
@@ -45,10 +46,36 @@ commentRouter.post('/:id/replies', sanitize, async (req: Request, res: Response)
 
 commentRouter.get('/:id/reactions', async (req: Request, res: Response) => {
   try {
+    const commentId = Number(req.params.id)
+    if (!Number.isInteger(commentId) || commentId <= 0) {
+      res.status(400).json({ error: 'Invalid comment id' })
+      return
+    }
+    const currentUserId = extractUserId(req)
+    const comment = await Comment.findByPk(commentId)
+
+    if (!comment) {
+      res.status(404).json({ error: 'Comment not found' })
+      return
+    }
+
     const reactions = await Reaction.findAll({
-      where: { comment_id: req.params.id },
+      where: { comment_id: commentId },
     })
-    res.json(reactions)
+
+    const { reactionSummary, myReactions } = summarizeReactions(
+      reactions.map(reaction => ({
+        emoji: reaction.emoji,
+        user_id: reaction.user_id,
+      })),
+      currentUserId
+    )
+
+    res.json({
+      comment_id: commentId,
+      reactionSummary,
+      myReactions,
+    })
   } catch (err) {
     console.error('Failed to fetch reactions:', err)
     res.status(500).json({ error: 'Internal Server Error' })
@@ -57,19 +84,75 @@ commentRouter.get('/:id/reactions', async (req: Request, res: Response) => {
 
 commentRouter.post('/:id/reactions', sanitize, async (req: Request, res: Response) => {
   try {
-    const { emoji, user_id } = req.body
+    const commentId = Number(req.params.id)
+    if (!Number.isInteger(commentId) || commentId <= 0) {
+      res.status(400).json({ error: 'Invalid comment id' })
+      return
+    }
+    const { emoji } = req.body
+    const userId = extractUserId(req)
 
-    if (!emoji || !user_id) {
-      res.status(400).json({ error: 'Emoji and user_id are required' })
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
       return
     }
 
-    const reaction = await Reaction.create({
-      emoji,
-      user_id,
-      comment_id: Number(req.params.id),
+    if (!emoji || typeof emoji !== 'string') {
+      res.status(400).json({ error: 'Emoji is required' })
+      return
+    }
+
+    if (!isAllowedReactionEmoji(emoji)) {
+      res.status(400).json({ error: 'Emoji is not allowed' })
+      return
+    }
+
+    const comment = await Comment.findByPk(commentId)
+
+    if (!comment) {
+      res.status(404).json({ error: 'Comment not found' })
+      return
+    }
+
+    const existingReaction = await Reaction.findOne({
+      where: {
+        emoji,
+        user_id: userId,
+        comment_id: commentId,
+      },
     })
-    res.status(201).json(reaction)
+
+    let status: 'added' | 'removed' = 'added'
+
+    if (existingReaction) {
+      await existingReaction.destroy()
+      status = 'removed'
+    } else {
+      await Reaction.create({
+        emoji,
+        user_id: userId,
+        comment_id: commentId,
+      })
+    }
+
+    const reactions = await Reaction.findAll({
+      where: { comment_id: commentId },
+    })
+
+    const { reactionSummary, myReactions } = summarizeReactions(
+      reactions.map(reaction => ({
+        emoji: reaction.emoji,
+        user_id: reaction.user_id,
+      })),
+      userId
+    )
+
+    res.status(200).json({
+      status,
+      comment_id: commentId,
+      reactionSummary,
+      myReactions,
+    })
   } catch (err) {
     console.error('Failed to add reaction:', err)
     res.status(500).json({ error: 'Internal Server Error' })

--- a/packages/server/routes/topicRouter.ts
+++ b/packages/server/routes/topicRouter.ts
@@ -1,9 +1,77 @@
 import { Router, Request, Response } from 'express'
 import { Topic } from '../models/Topic'
 import { Comment } from '../models/Comment'
+import { Reaction } from '../models/Reaction'
 import { sanitize } from '../middleware/sanitize'
+import { extractUserId, summarizeReactions } from '../lib/reactions'
 
 export const topicRouter = Router()
+
+type CommentWithRelations = {
+  id: number
+  content: string
+  author_id: string
+  topic_id: number
+  parentId: number | null
+  createdAt: string
+  updatedAt: string
+  reactions?: Array<{ emoji: string; user_id: number }>
+  replies?: CommentWithRelations[]
+}
+
+type CommentWithReactionSummary = Omit<CommentWithRelations, 'reactions' | 'replies'> & {
+  reactionSummary: Array<{ emoji: string; count: number }>
+  myReactions: string[]
+  replies: CommentWithReactionSummary[]
+}
+
+function withReactionSummary(
+  comment: CommentWithRelations,
+  currentUserId: number | null
+): CommentWithReactionSummary {
+  const { reactions: rawReactions, replies: rawReplies, ...rest } = comment
+  const reactions = Array.isArray(rawReactions) ? rawReactions : []
+  const replies = Array.isArray(rawReplies) ? rawReplies : []
+  const { reactionSummary, myReactions } = summarizeReactions(reactions, currentUserId)
+
+  return {
+    ...rest,
+    reactionSummary,
+    myReactions,
+    replies: replies.map(reply => withReactionSummary(reply, currentUserId)),
+  }
+}
+
+function buildCommentTree(comments: CommentWithRelations[]): CommentWithRelations[] {
+  const byId = new Map<number, CommentWithRelations>()
+  const roots: CommentWithRelations[] = []
+
+  for (const comment of comments) {
+    byId.set(comment.id, {
+      ...comment,
+      replies: [],
+    })
+  }
+
+  for (const comment of byId.values()) {
+    const parentId = comment.parentId
+
+    if (parentId === null) {
+      roots.push(comment)
+      continue
+    }
+
+    const parent = byId.get(parentId)
+
+    if (parent) {
+      parent.replies = [...(parent.replies || []), comment]
+    } else {
+      roots.push(comment)
+    }
+  }
+
+  return roots
+}
 
 topicRouter.get('/', async (_req: Request, res: Response) => {
   try {
@@ -54,14 +122,23 @@ topicRouter.get('/:id', async (req: Request, res: Response) => {
 
 topicRouter.get('/:id/comments', async (req: Request, res: Response) => {
   try {
+    const currentUserId = extractUserId(req)
+    const topicId = Number(req.params.id)
+
+    if (!Number.isInteger(topicId) || topicId <= 0) {
+      res.status(400).json({ error: 'Invalid topic id' })
+      return
+    }
+
     const comments = await Comment.findAll({
-      where: { topic_id: req.params.id, parentId: null },
-      include: [
-        { model: Comment, as: 'replies', include: [{ all: true, nested: true }] },
-        { all: true },
-      ],
+      where: { topic_id: topicId },
+      include: [{ model: Reaction, attributes: ['emoji', 'user_id'] }],
+      order: [['createdAt', 'ASC']],
     })
-    res.json(comments)
+
+    const tree = buildCommentTree(comments.map(comment => comment.toJSON() as CommentWithRelations))
+
+    res.json(tree.map(comment => withReactionSummary(comment, currentUserId)))
   } catch (err) {
     console.error('Failed to fetch comments:', err)
     res.status(500).json({ error: 'Internal Server Error' })


### PR DESCRIPTION
Реализована фича реакций на комментарии.

Что добавлено:
1. На комментарии можно ставить эмодзи-реакции (toggle: повторный клик снимает реакцию).
2. Сервер возвращает удобные данные: reactionSummary — сколько раз нажали каждый эмодзи; myReactions — какие эмодзи выбрал текущий пользователь.
5. На клиенте добавлены кнопки реакций под комментарием и счётчики.
6. Реакции без авторизации теперь не отправляются.
7. В forum-запросах включил credentials: 'include', чтобы сессия уходила в cookie.
8. Исправил загрузку дерева комментариев: теперь не теряются глубокие ответы (reply на reply и т.д.).
9. Исправил гонку запросов при быстрых кликах по реакции: старые ответы больше не перетирают новые.